### PR TITLE
toPath now works recursively

### DIFF
--- a/spec/spec/svg.topath.js
+++ b/spec/spec/svg.topath.js
@@ -361,12 +361,12 @@ describe('toPath()', function() {
     it('generates paths', function() {
 			nestedSVG.toPath();
 			expect(getStructure(nestedSVG.node)).toEqual({type:"svg",
-																								children:[
-																									{type:"polyline"},
-																									{type:"path"},
-																									{type:"rect"},
-																									{type:"path"}
-																								]});
+																										children:[
+																											{type:"polyline"},
+																											{type:"path"},
+																											{type:"rect"},
+																											{type:"path"}
+																										]});
     })
 		it('generates paths in subgroups', function() {
 			subgroup = nestedSVG.group();
@@ -374,16 +374,16 @@ describe('toPath()', function() {
 			
 			nestedSVG.toPath();
 			expect(getStructure(nestedSVG.node)).toEqual({type:"svg",
-																								children:[
-																									{type:"polyline"},
-																									{type:"path"},
-																									{type:"rect"},
-																									{type:"path"},
-																									{type:"g",children:[
-																										{type:"ellipse"},
-																										{type:"path"},
-																									]}
-																								]});
+																										children:[
+																											{type:"polyline"},
+																											{type:"path"},
+																											{type:"rect"},
+																											{type:"path"},
+																											{type:"g",children:[
+																												{type:"ellipse"},
+																												{type:"path"},
+																											]}
+																										]});
     })
 		it('generates paths in subgroups and replaces', function() {
 			subgroup = nestedSVG.group();
@@ -391,12 +391,28 @@ describe('toPath()', function() {
 			
 			nestedSVG.toPath(true);
 			expect(getStructure(nestedSVG.node)).toEqual({type:"svg",
+																										children:[
+																											{type:"path"},
+																											{type:"path"},
+																											{type:"g",children:[
+																												{type:"path"}
+																											]}
+																										]});
+    })
+		it('generates paths and ignores unsupported types', function() {
+			// create a node that toPath doesn't support
+			draw.defs()
+			draw.toPath();
+			expect(getStructure(draw.node)).toEqual({	type:"svg",
 																								children:[
-																									{type:"path"},
-																									{type:"path"},
-																									{type:"g",children:[
+																									{type:"svg",
+																									children:[
+																										{type:"polyline"},
+																										{type:"path"},
+																										{type:"rect"},
 																										{type:"path"}
-																									]}
+																									]},
+																									{type:"defs"}
 																								]});
     })
   })

--- a/svg.topath.js
+++ b/svg.topath.js
@@ -1,7 +1,7 @@
 // svg.topath.js 0.3 - Copyright (c) 2014 Wout Fierens - Licensed under the MIT license
 ;(function() {
 
-	SVG.extend(SVG.Element, {
+	SVG.extend(SVG.Shape, {
 		// Convert element to path
 		toPath: function(replace) {
 			var	w, h, rx, ry, d, path
@@ -110,20 +110,8 @@
 					x = box.x
 					y = box.y
 				break
-				case 'g':
-				case 'svg':
-					// cloning children array so that we don't touch the paths we create
-					var children = this.node.children;
-					var childrenClone = [];
-					for (var i = 0; i < children.length; i++) {
-						childrenClone.push(children[i].instance);
-					}
-					for (var i in childrenClone) {
-						childrenClone[i].toPath(replace);
-					}
-					break;
 				default: 
-					console.log('SVG toPath got unexpected type ' + this.type, this)
+					console.log('SVG toPath got unsupported type ' + this.type, this)
 					break;
 			}
 
@@ -152,6 +140,32 @@
 			}
 
 			return path
+		}
+
+	})
+	SVG.extend(SVG.Parent, {
+		// Convert element to path
+		toPath: function(replace) {
+			
+			switch(this.type) {
+				case 'g':
+				case 'svg':
+					// cloning children array so that we don't touch the paths we create
+					var children = this.node.children;
+					var childrenClone = [];
+					for (var i = 0; i < children.length; i++) {
+						childrenClone.push(children[i].instance);
+					}
+					for (var i in childrenClone) {
+//						console.log("  child:",childrenClone[i].type,childrenClone[i]);
+						childrenClone[i].toPath(replace);
+					}
+					break;
+				default: 
+					console.log('SVG toPath got unsupported type ' + this.type, this)
+					break;
+			}
+			return this
 		}
 
 	})


### PR DESCRIPTION
When called on groups or nested svg’s
Tests included
